### PR TITLE
Added support to multiline notifications on Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 
 [![npm version](https://badge.fury.io/js/de.appplant.cordova.plugin.local-notification.svg)](http://badge.fury.io/js/de.appplant.cordova.plugin.local-notification)
-[![PayPayl donate button](https://img.shields.io/badge/paypal-donate-yellow.svg)](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=L3HKQCD9UA35A "Donate once-off to this project using Paypal")
+Temporary Fork of Cordova Local-Notification Plugin to fix Android notification led issues.
 
 Cordova Local-Notification Plugin
 =================================

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
-  "name": "de.appplant.cordova.plugin.local-notification",
+  "name": "cordova-plugin-local-notifications-mm",
   "cordova_name": "Cordova LocalNotification Plugin",
-  "version": "0.8.4",
+  "version": "1.0.4",
   "description": "Schedules and queries for local notifications",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/katzer/cordova-plugin-local-notifications.git"
+    "url": "git+https://github.com/dpalou/cordova-plugin-local-notifications.git"
   },
   "keywords": [
     "appplant",

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,8 +2,8 @@
 
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
         xmlns:android="http://schemas.android.com/apk/res/android"
-        id="de.appplant.cordova.plugin.local-notification"
-        version="0.8.4">
+        id="cordova-plugin-local-notifications-mm"
+        version="1.0.4">
 
     <name>LocalNotification</name>
 

--- a/src/android/notification/Builder.java
+++ b/src/android/notification/Builder.java
@@ -118,6 +118,8 @@ public class Builder {
         Uri sound     = options.getSoundUri();
         int smallIcon = options.getSmallIcon();
         int ledColor  = options.getLedColor();
+        String summaryText = options.getSummaryText();
+        java.util.List<String> extendedTextLines = options.getExtendedTextLines();
         NotificationCompat.Builder builder;
 
         builder = new NotificationCompat.Builder(context)
@@ -143,6 +145,16 @@ public class Builder {
         } else {
             builder.setSmallIcon(options.getSmallIcon());
             builder.setLargeIcon(options.getIconBitmap());
+        }
+
+        if(extendedTextLines != null){
+            NotificationCompat.InboxStyle inboxStyle = new NotificationCompat.InboxStyle(builder);
+            if(summaryText != null){
+                inboxStyle.setSummaryText(summaryText);
+            }
+            for (String extendedTextLine : extendedTextLines) {
+                inboxStyle.addLine(extendedTextLine);
+            }
         }
 
         applyDeleteReceiver(builder);

--- a/src/android/notification/Options.java
+++ b/src/android/notification/Options.java
@@ -165,6 +165,33 @@ public class Options {
     }
 
     /**
+     * Summary text for the local notification.
+     */
+    public String getSummaryText() {
+        return options.optString("summary", null);
+    }
+
+    /**
+     * Text to show when notification is "opened" for the local notification.
+     */
+    public java.util.List<String> getExtendedTextLines() {
+        org.json.JSONArray arr;
+        try {
+            arr = options.getJSONArray("extendedTextLines");
+        } catch (JSONException e) {
+            return null;
+        }
+        java.util.List<String> list = new java.util.ArrayList<String>();
+        for(int i = 0; i < arr.length(); i++){
+            try {
+                list.add(arr.getString(i));
+            } catch (JSONException e) {
+            }
+        }
+        return list;
+    }
+
+    /**
      * Repeat interval (day, week, month, year, aso.)
      */
     public long getRepeatInterval() {

--- a/www/local-notification-util.js
+++ b/www/local-notification-util.js
@@ -63,14 +63,16 @@ exports.applyPlatformSpecificOptions = function () {
 
     switch (device.platform) {
     case 'Android':
-        defaults.icon      = 'res://ic_popup_reminder';
-        defaults.smallIcon = undefined;
-        defaults.ongoing   = false;
-        defaults.autoClear = true;
-        defaults.led       = undefined;
-        defaults.ledOnTime = undefined;
-        defaults.ledOffTime = undefined;
-        defaults.color     = undefined;
+        defaults.icon              = 'res://ic_popup_reminder';
+        defaults.smallIcon         = undefined;
+        defaults.ongoing           = false;
+        defaults.autoClear         = true;
+        defaults.led               = undefined;
+        defaults.ledOnTime         = undefined;
+        defaults.ledOffTime        = undefined;
+        defaults.color             = undefined;
+        defaults.summary           = undefined;
+        defaults.extendedTextLines = undefined;
         break;
     }
 


### PR DESCRIPTION
Let's say you get two notifications, but it's about the same issue.
Unfortunately the "group" https://developer.android.com/reference/android/support/v4/app/NotificationCompat.Builder.html#setGroup(java.lang.String) is not supported prier to Android N.

So my answer was to update that notice with a multiline notice, with one line per message.
As the working example:
`cordova.plugins.notification.local.schedule({`
`id: 1,`
`title: "Message about tomatoes",`
`text: "Red tomatoes...",`
`icon: "/platforms/android/res/drawable-mdpi/icon.png"`
`});`
`setTimeout(function(){`
`cordova.plugins.notification.local.schedule({`
`id: 1,`
`title: "Message about tomatoes",`
`text: "2 messages", /* this is shown when the notification is compacted (not opened) */`
`summary: "2 messages", /* this is optional and is shown at the bottom of the notification */`
`extendedTextLines: ["Red tomatoes...", "A lot of them"],`
`icon: "/platforms/android/res/drawable-mdpi/icon.png"`
`});`
`}, 10000);`
